### PR TITLE
s22-4pm-4: hn added showLeaderboard boolean variable to database

### DIFF
--- a/.env copy.SAMPLE
+++ b/.env copy.SAMPLE
@@ -1,4 +1,0 @@
-GOOGLE_CLIENT_ID=see-instructions-in-readme
-GOOGLE_CLIENT_SECRET=see-instructions-in-readme
-ADMIN_EMAILS=phtcon@ucsb.edu
-MONGODB_URI=see-instructions-in-readme

--- a/.env copy.SAMPLE
+++ b/.env copy.SAMPLE
@@ -1,0 +1,4 @@
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+ADMIN_EMAILS=phtcon@ucsb.edu
+MONGODB_URI=see-instructions-in-readme

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,6 +86,7 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
+    updated.setShowLeaderboard(params.isShowLeaderboard());
 
     commonsRepository.save(updated);
 
@@ -117,6 +118,7 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
+      .showLeaderboard(params.isShowLeaderboard())
       .build();
 
     Commons saved = commonsRepository.save(commons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -30,6 +30,8 @@ public class Commons
   private double startingBalance;
   private LocalDateTime startingDate;
 
+  private boolean showLeaderboard;
+
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",
     joinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"),

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -27,4 +27,6 @@ public class CreateCommonsParams
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
   @DateTimeFormat private LocalDateTime startingDate;
+
+  private boolean showLeaderboard;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -72,6 +72,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .showLeaderboard(true)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -80,6 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .showLeaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -133,6 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .showLeaderboard(true)
       .build();
 
     Commons commons = Commons.builder()
@@ -141,6 +144,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .showLeaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);


### PR DESCRIPTION
The showLeaderboard field was added to the backend. This field can be manipulated using the update or create controllers.

The showLeaderboard variable for the update controller:
<img width="554" alt="Screen Shot 2022-05-26 at 2 47 02 PM" src="https://user-images.githubusercontent.com/77522068/170585730-7210bd5f-7bc9-42fa-a945-8c8cb0f7bf57.png">

The showLeaderboard variable for the create controller:
<img width="573" alt="Screen Shot 2022-05-26 at 2 53 54 PM" src="https://user-images.githubusercontent.com/77522068/170586290-bcf2c900-7c1e-4341-a890-1a464c59de10.png">

The showLeaderboard variable in h2console:
<img width="200" alt="Screen Shot 2022-05-26 at 2 50 41 PM" src="https://user-images.githubusercontent.com/77522068/170585890-5c0c8aed-8dfa-4786-b283-eaee13bc9e2f.png">

Closes #19 
