### PR TITLE
s22-4pm-4: Vr backend degradation rate field added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HappyCows/HappierCows
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows/branch/master/graph/badge.svg?token=YedCF0lpyN)](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows/branch/main/graph/badge.svg?token=YedCF0lpyN)](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows)
 
 # Storybook
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HappyCows/HappierCows
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-6pm-HappyCows/branch/main/graph/badge.svg?token=F9AydNAnCV)](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-6pm-HappyCows)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows/branch/master/graph/badge.svg?token=YedCF0lpyN)](https://codecov.io/gh/ucsb-cs156-s22/s22-4pm-happycows)
 
 # Storybook
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 4pm-3:
 * [Production](https://s22-4pm-happycows.herokuapp.com)
 * [QA](https://s22-4pm-3-happycows-qa.herokuapp.com/)
+* [QA Heroku Dashboard](https://dashboard.heroku.com/apps/s22-4pm-3-happycows-qa)
 
 4pm-4:
 * [Production](https://s22-4pm-happycows.herokuapp.com)
 * [QA](https://s22-4pm-4-happycows-qa.herokuapp.com/)
-* [QA Heroku Dashboard](https://dashboard.heroku.com/apps/s22-4pm-4-happycows-qa)=======
+* [QA Heroku Dashboard](https://dashboard.heroku.com/apps/s22-4pm-4-happycows-qa)
 
 
 # Description

--- a/src/main/java/edu/ucsb/cs156/happiercows/advice/HappierCowsControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/advice/HappierCowsControllerAdvice.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.happiercows.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class HappierCowsControllerAdvice {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void handleIllegalArgumentException() {
+        log.error("IllegalArgumentException thrown");
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,6 +86,11 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
+    updated.setDegradationRate(params.getDegradationRate()); 
+
+    if(params.getDegradationRate() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+    }
 
     commonsRepository.save(updated);
 
@@ -117,7 +122,13 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
+      .degradationRate(params.getDegradationRate())
       .build();
+
+    //throw exception for degradation rate 
+    if(params.getDegradationRate() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+    }
 
     Commons saved = commonsRepository.save(commons);
     String body = mapper.writeValueAsString(saved);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -92,7 +92,6 @@ public class CommonsController extends ApiController {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
     }
     updated.setShowLeaderboard(params.isShowLeaderboard());
-    //update degradation field here 
 
     commonsRepository.save(updated);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,6 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
+  private double degradationRate;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -27,4 +27,5 @@ public class CreateCommonsParams
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
   @DateTimeFormat private LocalDateTime startingDate;
+  @NumberFormat private double degradationRate; 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -105,6 +105,52 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedResponse, actualResponse);
   }
 
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void createCommonsTest_withIllegalDegradationRate() throws Exception {
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    Commons commons = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(-8.49)
+        .build();
+
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(-8.49)
+        .build();
+
+    String requestBody = objectMapper.writeValueAsString(parameters);
+    String expectedResponse = objectMapper.writeValueAsString(commons);
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/new").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+        .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+    //someException.ifPresent((se) -> assertNotNull(se));
+    //someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
+
+    assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+  }
+
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsTest() throws Exception {
@@ -222,8 +268,6 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     verify(commonsRepository, times(1)).save(commons);
 
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
     // added lines for testing deg rate
     parameters.setDegradationRate(-10);
     commons.setDegradationRate(parameters.getDegradationRate());
@@ -246,12 +290,11 @@ public class CommonsControllerTests extends ControllerTestCase {
     Optional<IllegalArgumentException> someException = Optional
         .ofNullable((IllegalArgumentException) response.getResolvedException());
 
-    someException.ifPresent((se) -> assertNotNull(se));
-    someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
+    //someException.ifPresent((se) -> assertNotNull(se));
+    //someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
 
-    // TODO: Need to figure out what should be verified here
-    
-    // verify(commonsRepository, times(1)).save(commons);
+    assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
   }
 
   // This common SHOULD be in the repository

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -107,6 +107,49 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
+  public void createCommonsTest_withDegradationRate_Zero() throws Exception {
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    Commons commons = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(0)
+        .build();
+
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(0)
+        .build();
+
+    String requestBody = objectMapper.writeValueAsString(parameters);
+    String expectedResponse = objectMapper.writeValueAsString(commons);
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/new").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    verify(commonsRepository, times(1)).save(commons);
+
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
   public void createCommonsTest_withIllegalDegradationRate() throws Exception {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
@@ -230,6 +273,68 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     verify(commonsRepository, times(1)).save(commons);
   }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
+
+    Commons commons = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
+
+    String requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    mockMvc
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isCreated());
+
+    verify(commonsRepository, times(1)).save(commons);
+
+    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+    commons.setMilkPrice(parameters.getMilkPrice());
+    // added lines for testing deg rate
+    parameters.setDegradationRate(0);
+    commons.setDegradationRate(parameters.getDegradationRate());
+
+    requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.findById(0L))
+        .thenReturn(Optional.of(commons));
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    mockMvc
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isNoContent());
+
+    verify(commonsRepository, times(1)).save(commons);
+  }
+
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
@@ -509,6 +614,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     assertEquals(expectedString, responseString);
   }
+
 
   @WithMockUser(roles = { "ADMIN" })
   @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -72,6 +72,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .degradationRate(8.49)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -80,6 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .degradationRate(8.49)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -133,6 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .degradationRate(8.49)
       .build();
 
     Commons commons = Commons.builder()
@@ -141,6 +144,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .degradationRate(8.49)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -159,6 +163,9 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
+    //added lines for testing deg rate 
+    parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
+    commons.setDegradationRate(parameters.getDegradationRate());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -174,6 +181,68 @@ public class CommonsControllerTests extends ControllerTestCase {
         .characterEncoding("utf-8")
         .content(requestBody))
       .andExpect(status().isNoContent());
+
+    verify(commonsRepository, times(1)).save(commons);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void updateCommonsTest_withIllegalDegradationRate() throws Exception
+  {
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+      .name("Jackson's Commons")
+      .cowPrice(500.99)
+      .milkPrice(8.99)
+      .startingBalance(1020.10)
+      .startingDate(someTime)
+      .degradationRate(8.49)
+      .build();
+
+    Commons commons = Commons.builder()
+      .name("Jackson's Commons")
+      .cowPrice(500.99)
+      .milkPrice(8.99)
+      .startingBalance(1020.10)
+      .startingDate(someTime)
+      .degradationRate(8.49)
+      .build();
+
+    String requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.save(commons))
+      .thenReturn(commons);
+
+    mockMvc
+      .perform(put("/api/commons/update?id=0").with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8")
+        .content(requestBody))
+      .andExpect(status().isCreated());
+
+    verify(commonsRepository, times(1)).save(commons);
+
+    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+    commons.setMilkPrice(parameters.getMilkPrice());
+    //added lines for testing deg rate 
+    parameters.setDegradationRate(-10);
+    commons.setDegradationRate(parameters.getDegradationRate());
+
+    requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.findById(0L))
+      .thenReturn(Optional.of(commons));
+
+    when(commonsRepository.save(commons))
+      .thenReturn(commons);
+
+    mockMvc
+      .perform(put("/api/commons/update?id=0").with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8")
+        .content(requestBody))
+      .andExpect(status().is(500));
 
     verify(commonsRepository, times(1)).save(commons);
   }
@@ -370,6 +439,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .degradationRate(8.49)
         .build();
       
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -191,8 +191,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         Optional<IllegalArgumentException> someException = Optional
         .ofNullable((IllegalArgumentException) response.getResolvedException());
 
-    //someException.ifPresent((se) -> assertNotNull(se));
-    //someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
 
     assertNotNull(someException.get());
         assertTrue(someException.get() instanceof IllegalArgumentException);
@@ -258,7 +256,6 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
-    // added lines for testing deg rate
     parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
     commons.setDegradationRate(parameters.getDegradationRate());
 
@@ -319,7 +316,6 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
-    // added lines for testing deg rate
     parameters.setDegradationRate(0);
     commons.setDegradationRate(parameters.getDegradationRate());
 
@@ -379,7 +375,6 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     verify(commonsRepository, times(1)).save(commons);
 
-    // added lines for testing deg rate
     parameters.setDegradationRate(-10);
     commons.setDegradationRate(parameters.getDegradationRate());
 
@@ -401,8 +396,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     Optional<IllegalArgumentException> someException = Optional
         .ofNullable((IllegalArgumentException) response.getResolvedException());
 
-    //someException.ifPresent((se) -> assertNotNull(se));
-    //someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
+
 
     assertNotNull(someException.get());
         assertTrue(someException.get() instanceof IllegalArgumentException);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -599,6 +599,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
     doNothing().when(commonsRepository).deleteById(2L);
+    doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
 
     MvcResult response = mockMvc.perform(
         delete("/api/commons?id=2")
@@ -607,6 +608,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     verify(commonsRepository, times(1)).findById(2L);
     verify(commonsRepository, times(1)).deleteById(2L);
+    verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
 
     String responseString = response.getResponse().getContentAsString();
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -8,8 +8,10 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -20,21 +22,21 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Optional;
+
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 
 import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
@@ -62,41 +64,40 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void createCommonsTest() throws Exception
-  {
+  public void createCommonsTest() throws Exception {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
     Commons commons = Commons.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
     String expectedResponse = objectMapper.writeValueAsString(commons);
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     MvcResult response = mockMvc
-      .perform(post("/api/commons/new").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isOk())
-      .andReturn();
+        .perform(post("/api/commons/new").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isOk())
+        .andReturn();
 
     verify(commonsRepository, times(1)).save(commons);
 
@@ -125,136 +126,142 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void updateCommonsTest() throws Exception
-  {
+  public void updateCommonsTest() throws Exception {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     Commons commons = Commons.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isCreated());
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isCreated());
 
     verify(commonsRepository, times(1)).save(commons);
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
-    //added lines for testing deg rate 
+    // added lines for testing deg rate
     parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
     commons.setDegradationRate(parameters.getDegradationRate());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.findById(0L))
-      .thenReturn(Optional.of(commons));
+        .thenReturn(Optional.of(commons));
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isNoContent());
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isNoContent());
 
     verify(commonsRepository, times(1)).save(commons);
   }
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void updateCommonsTest_withIllegalDegradationRate() throws Exception
-  {
+  public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     Commons commons = Commons.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(8.49)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isCreated());
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isCreated());
 
     verify(commonsRepository, times(1)).save(commons);
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
-    //added lines for testing deg rate 
+    // added lines for testing deg rate
     parameters.setDegradationRate(-10);
     commons.setDegradationRate(parameters.getDegradationRate());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.findById(0L))
-      .thenReturn(Optional.of(commons));
+        .thenReturn(Optional.of(commons));
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
-    mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().is(500));
+    MvcResult response = mockMvc
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isBadRequest()).andReturn();
 
-    verify(commonsRepository, times(1)).save(commons);
+    Optional<IllegalArgumentException> someException = Optional
+        .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+    someException.ifPresent((se) -> assertNotNull(se));
+    someException.ifPresent((se) -> assertTrue(se instanceof IllegalArgumentException));
+
+    // TODO: Need to figure out what should be verified here
+    
+    // verify(commonsRepository, times(1)).save(commons);
   }
 
-  //This common SHOULD be in the repository
+  // This common SHOULD be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsByIdTest_valid() throws Exception {
     Commons Commons1 = Commons.builder()
-      .name("TestCommons2")
-      .id(18L)
-      .build();
+        .name("TestCommons2")
+        .id(18L)
+        .build();
 
     when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
 
@@ -267,7 +274,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
   }
 
-  //This common SHOULD NOT be in the repository
+  // This common SHOULD NOT be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsByIdTest_invalid() throws Exception {
@@ -285,14 +292,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-  @WithMockUser(roles = { "USER"})
+  @WithMockUser(roles = { "USER" })
   @Test
   public void joinCommonsTest() throws Exception {
 
     Commons c = Commons.builder()
-      .id(2L)
-      .name("Example Commons")
-      .build();
+        .id(2L)
+        .name("Example Commons")
+        .build();
 
     UserCommons uc = UserCommons.builder()
         .userId(1L)
@@ -311,7 +318,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(),anyLong())).thenReturn(Optional.empty());
+    when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
     when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
 
@@ -329,14 +336,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseString, cAsJson);
   }
 
-  @WithMockUser(roles = { "USER"})
+  @WithMockUser(roles = { "USER" })
   @Test
   public void already_joined_common_test() throws Exception {
 
     Commons c = Commons.builder()
-      .id(2L)
-      .name("Example Commons")
-      .build();
+        .id(2L)
+        .name("Example Commons")
+        .build();
 
     UserCommons uc = UserCommons.builder()
         .userId(1L)
@@ -347,8 +354,9 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     String requestBody = mapper.writeValueAsString(uc);
 
-    //Instead of returning empty, we instead say that it already exists. We shouldn't create a new entry.
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L,1L)).thenReturn(Optional.of(uc));
+    // Instead of returning empty, we instead say that it already exists. We
+    // shouldn't create a new entry.
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
     when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
 
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
@@ -377,7 +385,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .build();
 
     String requestBody = mapper.writeValueAsString(uc);
-    
+
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
     MvcResult response = mockMvc
@@ -386,7 +394,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         .andExpect(status().is(404)).andReturn();
 
     verify(commonsRepository, times(1)).findById(eq(2L));
-
 
     Map<String, Object> responseMap = responseToJson(response);
 
@@ -429,11 +436,11 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-    @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteCommons_test_admin_exists() throws Exception {
-      LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-      Commons c = Commons.builder()
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    Commons c = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
@@ -441,50 +448,48 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(8.49)
         .build();
-      
-      when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-      doNothing().when(commonsRepository).deleteById(2L);
-      
-      MvcResult response = mockMvc.perform(
-              delete("/api/commons?id=2")
-                      .with(csrf()))
-              .andExpect(status().is(200)).andReturn();
-      
-      verify(commonsRepository, times(1)).findById(2L);
-      verify(commonsRepository, times(1)).deleteById(2L);
-      
-      String responseString = response.getResponse().getContentAsString();
-      
-      String expectedString = "{\"message\":\"commons with id 2 deleted\"}"; 
 
-      assertEquals(expectedString, responseString);
+    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+    doNothing().when(commonsRepository).deleteById(2L);
+
+    MvcResult response = mockMvc.perform(
+        delete("/api/commons?id=2")
+            .with(csrf()))
+        .andExpect(status().is(200)).andReturn();
+
+    verify(commonsRepository, times(1)).findById(2L);
+    verify(commonsRepository, times(1)).deleteById(2L);
+
+    String responseString = response.getResponse().getContentAsString();
+
+    String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
+
+    assertEquals(expectedString, responseString);
   }
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteCommons_test_admin_nonexists() throws Exception {
-      
-      when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-      
-      MvcResult response = mockMvc.perform(
-              delete("/api/commons?id=2")
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-      
-      verify(commonsRepository, times(1)).findById(2L);
-      
 
-      String responseString = response.getResponse().getContentAsString();
-      
-      String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
-      
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
+    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc.perform(
+        delete("/api/commons?id=2")
+            .with(csrf()))
+        .andExpect(status().is(404)).andReturn();
+
+    verify(commonsRepository, times(1)).findById(2L);
+
+    String responseString = response.getResponse().getContentAsString();
+
+    String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
+
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
   }
-  
-  
-  @WithMockUser(roles = {"ADMIN"})
+
+  @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteUserFromCommonsTest() throws Exception {
     UserCommons uc = UserCommons.builder()
@@ -497,7 +502,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L,1L)).thenReturn(Optional.of(uc));
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
 
     MvcResult response = mockMvc
         .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
@@ -512,7 +517,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseString, "");
   }
 
-  @WithMockUser(roles = {"ADMIN"})
+  @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
     UserCommons uc = UserCommons.builder()
@@ -525,19 +530,20 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     String requestBody = mapper.writeValueAsString(uc);
 
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L,1L)).thenReturn(Optional.empty());
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
 
     MvcResult response;
-    try{
+    try {
       response = mockMvc
-        .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(204)).andReturn();
+          .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+              .characterEncoding("utf-8").content(requestBody))
+          .andExpect(status().is(204)).andReturn();
 
-    //The way this works is very interesting. The error message is sent as the value of a nested exception.
-    }catch(Exception e){
+      // The way this works is very interesting. The error message is sent as the
+      // value of a nested exception.
+    } catch (Exception e) {
       assertEquals(e.toString(),
-      "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+          "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
     }
   }
 }


### PR DESCRIPTION
# Overview

I added backend code for a double variable called degradationRate. This variable takes in a decimal value (must be 0 or larger- no negatives).It throws an error if a negative rate is entered. I added code in the controller and entity for this variable. Appears on backend when run on localhosts.  (pull requests linked to issues on Kanban Board - this pull request covers two issues: adding Backend Degradation variable to Entity  and adding Degradation field to CommonsController) 
<img width="1009" alt="Screen Shot 2022-05-27 at 4 01 38 PM" src="https://user-images.githubusercontent.com/56047916/171289728-6fda2cdf-1ea1-4245-a253-9b4e19fe6e02.png">
<img width="721" alt="Screen Shot 2022-05-27 at 4 01 20 PM" src="https://user-images.githubusercontent.com/56047916/171289756-d9caf3ba-64e0-4a40-b96e-79feda7392df.png">
<img width="900" alt="Screen Shot 2022-05-27 at 4 00 01 PM" src="https://user-images.githubusercontent.com/56047916/171289763-b9755c0e-4a7b-46e9-a8e2-b5b7d4e94482.png">
<img width="206" alt="Screen Shot 2022-05-27 at 3 59 47 PM" src="https://user-images.githubusercontent.com/56047916/171289771-a757cffc-aae7-4a6f-ae0e-ebc3bac6ca21.png">

