### PR TITLE
Xz show leaderboard frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
+import AdminShowLeaderboardPage from "main/pages/AdminShowLeaderboardPage"; 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 
@@ -35,6 +36,9 @@ function App() {
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/showleaderboard/" element={<AdminShowLeaderboardPage />} />
         }
         <Route path="/play/:commonsId" element={<PlayPage />} />
       </Routes>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -38,7 +38,7 @@ function App() {
           hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
         }
         {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/showleaderboard/" element={<AdminShowLeaderboardPage />} />
+          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/leaderboard/:id" element={<AdminShowLeaderboardPage />} />
         }
         <Route path="/play/:commonsId" element={<PlayPage />} />
       </Routes>

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -13,6 +13,10 @@ export default function CommonsTable({ commons, currentUser }) {
         navigate(`/admin/editcommons/${cell.row.values.id}`)
     }
 
+    const navigateCallback = (cell) => {
+        navigate(`/admin/leaderboard/${cell.row.values.id}`)
+    }
+
     // Stryker disable all : hard to test for query caching
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
@@ -62,7 +66,8 @@ export default function CommonsTable({ commons, currentUser }) {
     const columnsIfAdmin = [
         ...columns,
         ButtonColumn("Edit", "primary", editCallback, testid),
-        ButtonColumn("Delete", "danger", deleteCallback, testid)
+        ButtonColumn("Delete", "danger", deleteCallback, testid),
+        ButtonColumn("Show Leaderboard", "primary", navigateCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -49,6 +49,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/showleaderboard">Show Leaderboard</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -49,7 +49,6 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
-                    <NavDropdown.Item href="/admin/showleaderboard">Show Leaderboard</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/AdminShowLeaderboardPage.js
+++ b/frontend/src/main/pages/AdminShowLeaderboardPage.js
@@ -1,0 +1,28 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+// import CommonsTable from 'main/components/Commons/CommonsTable';
+// import { useBackend } from 'main/utils/useBackend';
+// import { useCurrentUser } from "main/utils/currentUser";
+
+export default function AdminShowLeaderboardPage()
+{
+  // const { data: currentUser } = useCurrentUser();
+
+  // Stryker disable  all 
+//   const { data: leaderboard, error: _error, status: _status } =
+//     useBackend(
+//       ["/api/commons/all"],
+//       { method: "GET", url: "/api/commons/all" },
+//       []
+//     );
+  // Stryker enable  all 
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Show Leaderboard</h1>
+        {/* <CommonsTable commons={commons} currentUser={currentUser} /> */}
+      </div>
+    </BasicLayout>
+  )
+};

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -163,4 +163,28 @@ describe("AdminListCommonPage tests", () => {
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/editcommons/5'));
     });
+
+    test("what happens when you click show leaderboard as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+      
+        const showButton = screen.getByTestId(`${testId}-cell-row-0-col-Show Leaderboard-button`);
+        expect(showButton).toBeInTheDocument();
+
+        fireEvent.click(showButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/leaderboard/5'));
+    });
 });

--- a/frontend/src/tests/pages/AdminShowLeaderboard.test.js
+++ b/frontend/src/tests/pages/AdminShowLeaderboard.test.js
@@ -1,0 +1,167 @@
+// import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {render} from "@testing-library/react";
+// import mockConsole from "jest-mock-console";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AdminShowLeaderboardPage from "main/pages/AdminShowLeaderboardPage";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("AdminShowLeaderboardPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    // const testId = "Leaderboard";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        //axiosMock.onGet("/api/commons/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminShowLeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        //axiosMock.onGet("/api/commons/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminShowLeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    // test("renders three commons without crashing for admin user", async () => {
+    //     setupAdminUser();
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <AdminListCommonPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+    //     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
+    //     expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("1");
+    // });
+
+    // test("renders empty table when backend unavailable, user only", async () => {
+    //     setupUserOnly();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/commons/all").timeout();
+
+    //     const restoreConsole = mockConsole();
+
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <AdminListCommonPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+    //     restoreConsole();
+
+    //     expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    // });
+
+    // test("what happens when you click delete, admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+    //     axiosMock.onDelete("/api/commons", {params: {id: 5}}).reply(200, "Commons with id 5 was deleted");
+
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <AdminListCommonPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+    //     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5"); 
+
+    //     const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    //     expect(deleteButton).toBeInTheDocument();
+       
+    //     fireEvent.click(deleteButton);
+
+    //     await waitFor(() => { expect(mockToast).toBeCalledWith("Commons with id 5 was deleted") });
+    // });
+
+    // test("what happens when you click edit as an admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <AdminListCommonPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+      
+    //     const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    //     expect(editButton).toBeInTheDocument();
+
+    //     fireEvent.click(editButton);
+
+    //     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/editcommons/5'));
+    // });
+
+});


### PR DESCRIPTION
Finished show leaderboard in the list common fields with ids.
Each common will have its own leaderboard link which will lead to the leaderboard page for it.

<img width="1440" alt="Screen Shot 2022-05-31 at 4 36 55 PM" src="https://user-images.githubusercontent.com/20672326/171300838-f1f703a7-2808-425a-bd5f-fa4b1ba079d9.png">
<img width="1440" alt="Screen Shot 2022-05-31 at 4 36 49 PM" src="https://user-images.githubusercontent.com/20672326/171300841-75ea6bb4-5c7b-4696-9324-56fed23a71f4.png">
<img width="1369" alt="Screen Shot 2022-05-31 at 4 34 54 PM" src="https://user-images.githubusercontent.com/20672326/171300842-26837e01-d1ae-47aa-bf55-cc561ad691d6.png">
