### PR TITLE
s22-4pm-3 - Added Leaderboard button on Visit Commons Page

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -1,0 +1,36 @@
+const leaderboardFixtures = {
+    threeBoards: [
+        {
+            "commonsid": 1,
+            "playerName": "Jones",
+            "numOfCows": 50,
+            "amtOfMoney": 1500,
+            "averageCowHealth": 90
+        },
+        {
+            "commonsid": 2,
+            "playerName": "Washington",
+            "numOfCows": 100,
+            "amtOfMoney": 1000,
+            "averageCowHealth": 60
+        },
+        {
+            "commonsid": 3,
+            "playerName": "Moseby",
+            "numOfCows": 2,
+            "amtOfMoney": 4000,
+            "averageCowHealth": 100
+        }
+    ],
+    oneBoard: [
+        {
+            "commonsid": 1,
+            "playerName": "Jones",
+            "numOfCows": 50,
+            "amtOfMoney": 1500,
+            "averageCowHealth": 90
+        }
+    ],
+}
+
+export default leaderboardFixtures;

--- a/frontend/src/main/components/Leaderboard/LeaderboardButton.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardButton.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Card, Button } from "react-bootstrap";
+
+  
+
+const LeaderboardButton = () => {
+    return (
+        <Card>
+        <Card.Header as="h5">All Farms Stats</Card.Header>
+        <Card.Body>
+            <Button onClick={() => alert("The leaderboard has not been implemented yet")} data-testid={"leaderboard-button"}>See Leaderboard</Button>
+
+        </Card.Body>
+        </Card>
+    );
+}
+export default LeaderboardButton;

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -8,6 +8,7 @@ import CommonsOverview from "main/components/Commons/CommonsOverview";
 import CommonsPlay from "main/components/Commons/CommonsPlay";
 import FarmStats from "main/components/Commons/FarmStats";
 import ManageCows from "main/components/Commons/ManageCows";
+import LeaderboardButton from "main/components/Leaderboard/LeaderboardButton";
 import Profits from "main/components/Commons/Profits";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
@@ -131,6 +132,7 @@ export default function PlayPage() {
             <CardGroup >
               <ManageCows userCommons={userCommons} commons={commons} onBuy={onBuy} onSell={onSell} />
               <FarmStats userCommons={userCommons} />
+              <LeaderboardButton/>
               <Profits userCommons={userCommons} profits={userCommonsProfits} />
             </CardGroup>
           }

--- a/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
@@ -1,4 +1,3 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import LeaderboardButton from "main/components/Leaderboard/LeaderboardButton"; 
 
 describe("LeaderboardButton tests", () => {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
@@ -1,0 +1,11 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import LeaderboardButton from "main/components/Leaderboard/LeaderboardButton"; 
+
+describe("LeaderboardButton tests", () => {
+    test("renders without crashing", () => {
+        render(
+            <LeaderboardButton />
+        );
+    });
+
+});

--- a/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
@@ -1,3 +1,4 @@
+import { render } from "@testing-library/react";
 import LeaderboardButton from "main/components/Leaderboard/LeaderboardButton"; 
 
 describe("LeaderboardButton tests", () => {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardButton.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import LeaderboardButton from "main/components/Leaderboard/LeaderboardButton"; 
 
 describe("LeaderboardButton tests", () => {
@@ -6,6 +6,18 @@ describe("LeaderboardButton tests", () => {
         render(
             <LeaderboardButton />
         );
+    });
+
+    test("clicking LeaderboardButton", async () => {
+        render(
+            <LeaderboardButton />
+        );
+
+        const leaderboardButton = screen.getByTestId("leaderboard-button");
+        const alertMock = jest.spyOn(window,'alert').mockImplementation(); 
+        fireEvent.click(leaderboardButton);
+        expect(alertMock).toHaveBeenCalledTimes(1);
+
     });
 
 });


### PR DESCRIPTION
New column added to the existing card called "All Farm Stats". This section currently only holds this button placeholder, however could hold additional information about stats that represent the whole commons later. Button creates an alert, showing that it is a placeholder.