### PR TITLE
s22-4pm-3 cd - Update .gitignore to ignore .DS_Store OS generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ build/
 
 ### Local Configuration ###
 .env
+
+### OS generated ###
+.DS_Store


### PR DESCRIPTION
# Overview

Updated .gitignore in order to avoid unwanted files in PRs such as the OS generated file .DS_Store.

Closes #87 