### PR TITLE
s22-4pm-3 sw - Created an API call in commons controller to get all UserCommons based on Id to be used for the Leaderboard

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -63,9 +63,9 @@ public class CommonsController extends ApiController {
   }
 
   @ApiOperation(value = "Get a list of all UserCommons by commonsid")
-  @GetMapping("/allById")
-  public Iterable<UserCommons> getUserCommonsbyId(@ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
-    Iterable<UserCommons> userCommons = userCommonsRepository.findAllById(id);
+  @GetMapping("/allUserCommonsById")
+  public Iterable<UserCommons> getAllUserCommonsById(@ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+    Iterable<UserCommons> userCommons = userCommonsRepository.findAllByCommonsId(id);
     return userCommons;
   }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -35,6 +35,8 @@ import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.controllers.ApiController;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Api(description = "Commons")
@@ -58,6 +60,13 @@ public class CommonsController extends ApiController {
     Iterable<Commons> users = commonsRepository.findAll();
     String body = mapper.writeValueAsString(users);
     return ResponseEntity.ok().body(body);
+  }
+
+  @ApiOperation(value = "Get a list of all UserCommons by commonsid")
+  @GetMapping("/allById")
+  public Iterable<UserCommons> getUserCommonsbyId(@ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+    Iterable<UserCommons> userCommons = userCommonsRepository.findAllById(id);
+    return userCommons;
   }
 
   @ApiOperation(value = "Update a commons")

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -10,6 +10,6 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 @Repository
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
-
+    Iterable<UserCommons> findAllById(Long commonsid );
     void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -10,6 +10,6 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 @Repository
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
-    Iterable<UserCommons> findAllById(Long commonsid );
+    Iterable<UserCommons> findAllByCommonsId(Long commonsid );
     void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -217,7 +217,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void getUserCommonsbyId() throws Exception {
+  public void getAllUserCommonsById() throws Exception {
     List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
     UserCommons UserCommons1 = UserCommons
     .builder()
@@ -228,12 +228,22 @@ public class CommonsControllerTests extends ControllerTestCase {
     .numOfCows(1)
     .build();
 
+    UserCommons UserCommons2 = UserCommons
+    .builder()
+    .id(2L)
+    .userId(2L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
     expectedUserCommons.add(UserCommons1);
-    when(userCommonsRepository.findAllById(1L)).thenReturn(expectedUserCommons);
-    MvcResult response = mockMvc.perform(get("/api/commons/allById?id=1"))
+    expectedUserCommons.add(UserCommons2);
+    when(userCommonsRepository.findAllByCommonsId(1L)).thenReturn(expectedUserCommons);
+    MvcResult response = mockMvc.perform(get("/api/commons/allUserCommonsById?id=1"))
         .andExpect(status().isOk()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findAllById(1L);
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(1L);
 
     String responseString = response.getResponse().getContentAsString();
     List<UserCommons> actualUserCommons = objectMapper.readValue(responseString, new TypeReference<List<UserCommons>>() {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -217,7 +217,34 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void updateCommonsTest() throws Exception {
+  public void getUserCommonsbyId() throws Exception {
+    List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
+    UserCommons UserCommons1 = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    expectedUserCommons.add(UserCommons1);
+    when(userCommonsRepository.findAllById(1L)).thenReturn(expectedUserCommons);
+    MvcResult response = mockMvc.perform(get("/api/commons/allById?id=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllById(1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    List<UserCommons> actualUserCommons = objectMapper.readValue(responseString, new TypeReference<List<UserCommons>>() {
+    });
+    assertEquals(actualUserCommons, expectedUserCommons);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void updateCommonsTest() throws Exception
+  {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()


### PR DESCRIPTION
# Created an API call in commons controller to get all UserCommons based on Id to be used for the Leaderboard

## Description
This PR includes code that sets up the backend API for leaderboards. The frontend leaderboard component will use this to display a leaderboard for the users. The URL route is `api/commons/allById`. It also requires you pass in the id of the commons you want to find all the UserCommons for.


## Issue
Connected to the following issue #14 