### PR TITLE
s22-4pm-3 cd - User Commons initialized with 0 cows

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -160,7 +160,7 @@ public class CommonsController extends ApiController {
         .commonsId(commonsId)
         .userId(userId)
         .totalWealth(joinedCommons.getStartingBalance())
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -453,7 +453,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .userId(1L)
         .commonsId(2L)
         .totalWealth(0)
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     UserCommons ucSaved = UserCommons.builder()
@@ -461,7 +461,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .userId(1L)
         .commonsId(2L)
         .totalWealth(0)
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     String requestBody = mapper.writeValueAsString(uc);


### PR DESCRIPTION
# Overview

Fixes a small bug where a user commons is initialized with 1 cow instead of 0 cows upon joining a new commons.

Closes #91  