### PR TITLE
s22-4pm-3 cs - Leaderboard Fixtures Fixed: No duplicate User ID

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -23,7 +23,7 @@ const leaderboardFixtures = {
         },
         {
             "commonsId": 1,
-            "userId": 2,
+            "userId": 3,
             "numOfCows": 30,
             "totalWealth": 6000,
             "avgCowHealth": 100


### PR DESCRIPTION
# Overview

Changes the Leaderboard Fixtures file so there are is not a duplicate for the User ID


# Issues Addressed

Changed the duplicate "2" User ID to "3" in Leaderboard Fixtures

# Link to Storybook

https://ucsb-cs156-s22.github.io/s22-4pm-happycows-docs-qa/storybook-qa/Charanpreet-AddingLeaderboardReactComponent/?path=/story/components-leaderboard-leaderboardtable--empty

# Details
Before Fix
![image](https://user-images.githubusercontent.com/49246453/172075316-98d93e92-0262-4610-b00d-894e284ece19.png)

After Fix 
![image](https://user-images.githubusercontent.com/49246453/172075297-714c8fa1-8a8e-4eb7-a91c-3ee1a380d1d6.png)
